### PR TITLE
Add ccbutton option for Creative Commons licensing

### DIFF
--- a/R/html_template.R
+++ b/R/html_template.R
@@ -74,6 +74,9 @@ html_template <- function(
     if (!is.null(args[["favicon"]])) {
       pandoc_args <- c(pandoc_args, "--variable", paste0("favicon:", args[["favicon"]]))
     }
+    if (!is.null(args[["ccbutton"]])) {
+      pandoc_args <- c(pandoc_args, "--variable", paste0("ccbutton:", args[["ccbutton"]]))
+    }
     
     ## downcute default style
     if (!is.null(args[["default_style"]])) {

--- a/R/readthedown.R
+++ b/R/readthedown.R
@@ -47,6 +47,7 @@ readthedown <- function(fig_width = 8,
                        logo = NULL,
                        logo2 = NULL,
                        favicon = NULL,
+                       ccbutton = NULL,
                        ...) {
 
     html_template(
@@ -71,6 +72,7 @@ readthedown <- function(fig_width = 8,
         logo = logo,
         logo2 = logo2,
         favicon = favicon,
+        ccbutton = ccbutton,
         ...
     )
 

--- a/inst/templates/template.html
+++ b/inst/templates/template.html
@@ -329,6 +329,9 @@
       $if(date)$
       <p class="date"><span class="glyphicon glyphicon-calendar"></span> $date$</p>
       $endif$
+      $if(ccbutton)$
+	    $ccbutton$
+      $endif$
     </div>
    </div>
    $endif$  


### PR DESCRIPTION
The ccbutton option allows a space below the date in the postamble to be used to accommodate a Creative Commons License button. The value of ccbutton: should be a self-contained HTML string specifying the button source and the link to the license; the Creative Commons organization provides sample HTML for this purpose on its web site. 